### PR TITLE
Added escaping of error messages in the 'messages' attribute

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,11 @@ let package = Package(
     products: [
         .library(name: "SwiftTestReporter", targets: ["SwiftTestReporter"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/alexaubry/HTMLString.git", .upToNextMajor(from: "4.0.2")),
+    ],
     targets: [
-        .target(name: "SwiftTestReporter"),
+        .target(name: "SwiftTestReporter", dependencies: [ "HTMLString" ]),
         .testTarget(name: "SwiftTestReporterTests", dependencies: ["SwiftTestReporter"]),
     ]
 )

--- a/Sources/SwiftTestReporter/Reporters/JUnit/JUnitElement.swift
+++ b/Sources/SwiftTestReporter/Reporters/JUnit/JUnitElement.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HTMLString
 
 /// Describes all elements needed to build valid XML.
 indirect enum JUnitElement: CustomStringConvertible {
@@ -41,10 +42,10 @@ indirect enum JUnitElement: CustomStringConvertible {
             return testCaseElement
 
         case .failure(let message):
-            return "\n\t\t\t<failure message=\"\(message)\"></failure>\n\t\t"
+            return "\n\t\t\t<failure message=\"\(message.addingASCIIEntities)\"></failure>\n\t\t"
 
         case .error(let message):
-            return "\n\t\t\t<error message=\"\(message)\"></error>\n\t\t"
+            return "\n\t\t\t<error message=\"\(message.addingASCIIEntities)\"></error>\n\t\t"
         }
     }
 }

--- a/Tests/SwiftTestReporterTests/JUnitReporterTests.swift
+++ b/Tests/SwiftTestReporterTests/JUnitReporterTests.swift
@@ -51,9 +51,35 @@ class JUnitReporterTests: XCTestCase {
             XCTAssertEqual(content.replacingTabsWithSpaces(), expected.replacingTabsWithSpaces())
         }
     }
+    
+    func testProperEscapingOfErrorMessages() {
+        #if os(Linux)
+        let className = "SwiftTestReporterTests.JUnitReporterTests"
+        let testName = "testProperEscapingOfErrorMessages"
+        #else
+        let className = "-[JUnitReporterTests testProperEscapingOfErrorMessages]"
+        let testName = "-[JUnitReporterTests testProperEscapingOfErrorMessages]"
+        #endif
+        let testCase = Test(self).setFailure(Failure(message: "\"test\" \"failed\""))
+        let testSuite = makeTestCaseStub(name: "TestFoo", testCases: ["test": testCase])
+        let expected = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+            <testsuite tests="1" failures="1" disabled="0" errors="0" time="0.0" name="TestFoo">
+                <testcase classname="\(className)" name="\(testName)" time="0.0">
+                    <failure message="&#34;test&#34; &#34;failed&#34;"></failure>
+                </testcase>
+            </testsuite>
+        </testsuites>
+        """
+        JUnitReporter().report(for: [testSuite]) { content in
+            XCTAssertEqual(content.replacingTabsWithSpaces(), expected.replacingTabsWithSpaces())
+        }
+    }
 
     static var allTests = [
         ("testReporterShouldReturnXMLForEmptySuite", testReporterShouldReturnXMLForEmptySuite),
-        ("testReporterShouldReturnXMLForFailedTest", testReporterShouldReturnXMLForFailedTest)
+        ("testReporterShouldReturnXMLForFailedTest", testReporterShouldReturnXMLForFailedTest),
+        ("testProperEscapingOfErrorMessages", testProperEscapingOfErrorMessages),
     ]
 }


### PR DESCRIPTION
Without escaping of the error message, invalid XML can be generated that will fail to parse. An example would be a quote character (") was included in the error message.

NOTE: I added a dependency to the HTMLString library to provide functionality for the escaping, as it's non-trivial.  If this is undesired, I can manually add a local function for some of the standard possibilities, but of course, it won't be as complete.