### PR TITLE
Improve className resolution (#8)

### DIFF
--- a/Sources/SwiftTestReporter/TestObserver.swift
+++ b/Sources/SwiftTestReporter/TestObserver.swift
@@ -24,7 +24,7 @@ extension TestObserver: XCTestObservation {
         /// XCTest creates additional XCTestSuite:
         ///  - "All Test" which contains all test suites
         ///  - test suite for each module in tests (e.g. SwiftTestReporterTests)
-        let className = getXCTestClassName(testSuite)
+        let className = testSuite.customClassName
         return className == "XCTestCaseSuite"
     }
 

--- a/Sources/SwiftTestReporter/Utils.swift
+++ b/Sources/SwiftTestReporter/Utils.swift
@@ -4,16 +4,13 @@ private func lastChunk(_ phrase: String, separator: Character = ".") -> String {
     return phrase.split(separator: separator).last?.description ?? phrase
 }
 
-/// Simple helper that returns class name for XCTest.
-/// There are some difference beween original XCTest and XCTest in open source and this
-/// helper solves one of the problems - missing property (className).
-/// - Parameter obj: XCTest's instance
-/// - Returns: A normalized name for XCTest's instance
-func getXCTestClassName(_ obj: XCTest) -> String {
-    #if os(Linux)
-    let className = "\(obj.self)"
-    #else
-    let className = obj.className
-    #endif
-    return lastChunk(className)
+extension XCTest {
+    /// Simple helper that returns class name for XCTest.
+    /// There are some difference between original XCTest on different platforms and XCTest in open source and this
+    /// helper solves one of the problems - missing property (className).
+    /// - Returns: A normalized name for XCTest's instance
+    var customClassName : String {
+        let fullClassName = "\(type(of: self))"
+        return fullClassName
+    }
 }

--- a/Tests/SwiftTestReporterTests/UtilsTests.swift
+++ b/Tests/SwiftTestReporterTests/UtilsTests.swift
@@ -3,8 +3,14 @@ import XCTest
 
 class UtilsTests: XCTestCase {
     func testShouldReturnProperlyClassName() {
+        let xcTest: XCTest = self
+        XCTAssertEqual(xcTest.customClassName, "UtilsTests")
+    }
+
+    func testShouldReturnProperlyClassNameForNestedClass() {
         class FooTestCase: XCTest {}
-        XCTAssertEqual(getXCTestClassName(self), "UtilsTests")
+        let xcTest: XCTest = FooTestCase()
+        XCTAssertEqual(xcTest.customClassName, "FooTestCase")
     }
 
     static var allTests = [


### PR DESCRIPTION
`NSObject.className` is a MacOS only method (unsupported on iOS). I think we should drop the `NSObject.className` at all and use one mechanism for all the platforms. I ran the unit tests on:
- macOS,
- iOS.
I checked that this solution works on Linux, but the CI will show if I am right :)
