### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
-        swift: ["5.3", "5.4"]
+        os: [ubuntu-20.04, macos-12]
+        swift: ["5.5"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-11]
         swift: ["5.5"]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Swift Test Reporter
 
-![Swift 5.3](https://img.shields.io/badge/swift-5.3-brightgreen.svg)
-![Swift 5.4](https://img.shields.io/badge/swift-5.4-brightgreen.svg)
-![Linux](https://img.shields.io/badge/linux-brightgreen.svg)
-![MacOS](https://img.shields.io/badge/macos-brightgreen.svg)
+[![CI](https://github.com/allegro/swift-junit/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/allegro/swift-junit/actions/workflows/ci.yml)
 
 
 A Swift library for creating JUnit XML test results that can be interpreted by tools such as Bamboo or Jenkins.


### PR DESCRIPTION
Seems like GitHub workflow build farm can't support Swift < 5.5.

https://github.com/allegro/swift-junit/runs/5063641988?check_suite_focus=true